### PR TITLE
Initial functionality to write VTK FieldData

### DIFF
--- a/include/lean_vtk.hpp
+++ b/include/lean_vtk.hpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <tuple>
 
 namespace leanvtk {
 inline int index(int N, int i, int j) {
@@ -82,6 +83,14 @@ private:
 
 class VTUWriter {
 public:
+
+  void add_field_data(const std::string& type,
+                      const std::string& name,
+                      const int& value);
+  void add_field_data(const std::string& type,
+                      const std::string& name,
+                      const double& value);
+
   /**
    * Write surface mesh to a file
    * const string& path             filename to store vtk mesh (ending with .vtu)
@@ -341,6 +350,9 @@ public:
   void clear();
 
 private:
+  typedef std::tuple<std::string,std::string,int,double> FieldDataTuple;
+
+  std::vector<FieldDataTuple> field_data_;
   std::vector<VTKDataNode<double>> point_data_;
   std::vector<VTKDataNode<double>> cell_data_;
   std::string current_scalar_point_data_;
@@ -355,6 +367,8 @@ private:
 
   void write_header(const int n_vertices, const int n_elements,
                     std::ostream &os);
+
+  void write_field_data(std::ostream &os);
 
   void write_footer(std::ostream &os);
   

--- a/tests/test_lean_vtk.cpp
+++ b/tests/test_lean_vtk.cpp
@@ -21,6 +21,9 @@ TEST_CASE("Single elements", "[single]"){
     int cell_size;
     std::string filename;
     bool is_volume_mesh = false;
+
+    VTUWriter writer;
+
     SECTION("Triangle 2D"){
         points = {
              1.,  1.,
@@ -112,6 +115,8 @@ TEST_CASE("Single elements", "[single]"){
         filename = "single_quad.vtu";
     }
     SECTION("Hex element"){
+        writer.add_field_data("Int32","CYCLE",123);
+        writer.add_field_data("Float64","TIME",4.56);
         points = {
              1.,  1., 1.,
              1., -1., 1.,
@@ -156,7 +161,6 @@ TEST_CASE("Single elements", "[single]"){
         filename = "single_tet.vtu";
         is_volume_mesh = true;
     }
-    VTUWriter writer;
 
     writer.add_scalar_field("scalar_field", scalar_field);
     writer.add_vector_field("vector_field", vector_field, dim);


### PR DESCRIPTION
Currently only works for int and double scalars.  Verified to work for the intended use case . . .  Screenshot attached.  Functionality added to a single test ("single_hex").  Resolves #1 .

![Screen Shot 2021-09-14 at 9 01 23 AM](https://user-images.githubusercontent.com/34101746/133293103-75387691-5f3a-46e4-8bc3-9fc9f79d8387.png)
