### PR TITLE
Correct the include target file in LeanVTK-config.cmake

### DIFF
--- a/cmake/LeanVTK-config.cmake
+++ b/cmake/LeanVTK-config.cmake
@@ -10,4 +10,4 @@ find_dependency(LAPACK REQUIRED)
 # Any extra setup
 
 # Add the targets file
-include("${CMAKE_CURRENT_LIST_DIR}/CMakeDemoTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/LeanVTKTargets.cmake")

--- a/cmake/LeanVTK-config.cmake
+++ b/cmake/LeanVTK-config.cmake
@@ -4,9 +4,6 @@ include(CMakeFindDependencyMacro)
 # Capturing values from configure (optional)
 #set(my-config-var @my-config-var@)
 
-# Same syntax as find_package
-find_dependency(LAPACK REQUIRED)
-
 # Any extra setup
 
 # Add the targets file


### PR DESCRIPTION
Without this linking a target "LeanVTK::LeanVTK" in cmake does not work.