### PR TITLE
fix(core): Memory leak because of an invalid type when deleting

### DIFF
--- a/include/leanvtk.hpp
+++ b/include/leanvtk.hpp
@@ -141,6 +141,8 @@ public:
       , binary_(false)
   {}
 
+  virtual ~VTKDataNodeBase() = default;
+
   virtual void write(std::ostream &os) const
   {
   };


### PR DESCRIPTION
A small defect that causes some memory leaks